### PR TITLE
Adds more cli parameters and fixes windows tests

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -20,12 +20,14 @@ type builder struct {
 	errors string
 }
 
-func NewBuilder(dir string) Builder {
-	bin := "bin" // TODO: make this configurable? (via config.go? or as parameter to NewBuilder()?)
+func NewBuilder(dir string, bin string) Builder {
+	if len(bin) == 0 {
+		bin = "bin"
+	}
 
 	// does not work on Windows without the ".exe" extension
 	if runtime.GOOS == "windows" {
-		if !strings.HasSuffix(bin, ".exe") { // if "bin" becomes configurable we should check if it already has the .exe extension
+		if !strings.HasSuffix(bin, ".exe") { // check if it already has the .exe extension
 			bin += ".exe"
 		}
 	}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,35 +1,41 @@
 package gin_test
 
 import (
+	"fmt"
 	"github.com/codegangsta/gin"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func Test_Builder_Build_Success(t *testing.T) {
-	wd := "test_fixtures/build_success/"
+	wd := filepath.Join("test_fixtures", "build_success")
+	bin := "build_success"
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 
-	builder := gin.NewBuilder(wd)
+	builder := gin.NewBuilder(wd, bin)
 	err := builder.Build()
 	expect(t, err, nil)
 
-	file, err := os.Open(wd + "build_success")
-
+	file, err := os.Open(filepath.Join(wd, bin))
 	if err != nil {
-		t.Fatal("File has not been written")
+		t.Fatalf("File has not been written: %v", err)
 	}
 
 	refute(t, file, nil)
 }
 
 func Test_Builder_Build_Failure(t *testing.T) {
-	wd := "test_fixtures/build_failure/"
+	wd := filepath.Join("test_fixtures", "build_failure")
 
-	builder := gin.NewBuilder(wd)
+	builder := gin.NewBuilder(wd, "bin")
 	err := builder.Build()
 	refute(t, err, nil)
 
-	expect(t, strings.Contains(builder.Errors(), "./main.go:4: undefined: this"), true)
-	expect(t, strings.Contains(builder.Errors(), "./main.go:4: undefined: compile"), true)
+	expect(t, strings.Contains(builder.Errors(), fmt.Sprintf(".%smain.go:4: undefined: this", string(os.PathSeparator))), true)
+	expect(t, strings.Contains(builder.Errors(), fmt.Sprintf(".%smain.go:4: undefined: compile", string(os.PathSeparator))), true)
 }

--- a/main/gin/gin.go
+++ b/main/gin/gin.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	startTime    = time.Now()
-	helpTemplate = "gin - live reload for martini\nusage: {{.Name}} [-v|--version] [-h|--help] [(-p|--port)=<port>]\n"
+	helpTemplate = "gin - live reload for martini\nusage: {{.Name}} [-v|--version] [-h|--help] [(-p|--port)=<port>] [(-a|--appPort)=<appPort>] [(-b|--bin)=<binary>]\n"
 	logger       = log.New(os.Stdout, "[gin] ", 0)
 	buildError   error
 )
@@ -29,6 +29,8 @@ func main() {
 	app.Action = MainAction
 	app.Flags = []cli.Flag{
 		cli.IntFlag{"port,p", 3000, "port for the proxy server"},
+		cli.IntFlag{"appPort,a", 3001, "port for the martini web server"},
+		cli.StringFlag{"bin,b", "gin-bin", "name of generated binary file"},
 	}
 
 	app.Run(os.Args)
@@ -36,7 +38,7 @@ func main() {
 
 func MainAction(c *cli.Context) {
 	port := c.Int("port")
-	appPort := strconv.Itoa(port + 1)
+	appPort := strconv.Itoa(c.Int("appPort"))
 	os.Setenv("PORT", appPort)
 
 	wd, err := os.Getwd()
@@ -44,7 +46,7 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(".")
+	builder := gin.NewBuilder(".", c.String("bin"))
 	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()))
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -64,7 +64,7 @@ func Test_Proxying_Build_Errors(t *testing.T) {
 	proxy := gin.NewProxy(builder, runner)
 
 	config := &gin.Config{
-		Port:    5678,
+		Port:    5679,
 		ProxyTo: "http://localhost:3000",
 	}
 
@@ -72,7 +72,7 @@ func Test_Proxying_Build_Errors(t *testing.T) {
 	defer proxy.Close()
 	expect(t, err, nil)
 
-	res, err := http.Get("http://localhost:5678")
+	res, err := http.Get("http://localhost:5679")
 	expect(t, err, nil)
 	expect(t, res == nil, false)
 	errors, err := ioutil.ReadAll(res.Body)

--- a/test_fixtures/writing_output.bat
+++ b/test_fixtures/writing_output.bat
@@ -1,0 +1,1 @@
+@echo Hello world


### PR DESCRIPTION
This will fix test cases to work on windows (different path separator, different behaviour for running binaries, CRLF, etc..).

Also adds two additional commandline parameters, for defining the appPort and the generated binary filename.
