### PR TITLE
Add fsnotify support to gin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,13 @@ Then verify that `gin` was installed correctly:
 gin -h
 ~~~
 
+## Installing with fsnotify support
+
+If you're in an evironment like Linux, your operating system may support fsnotify events to trigger rebuilds. If you'd like support for this you can use the following command instead of the one above:
+
+~~~ shell
+go get -tags fsnotify github.com/codegangsta/gin
+~~~
+
 ## Supporting Gin in Your Web app
 `gin` assumes that your web app binds itself to the `PORT` environment variable so it can properly proxy requests to your app. Web frameworks like [Martini](http://github.com/codegangsta/martini) do this out of the box.

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -1,0 +1,46 @@
+//+build fsnotify
+// Only build when the fsnotify tag is used
+
+package main
+
+import (
+	"code.google.com/p/go.exp/fsnotify"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func scanChanges(watchPath string, cb scanCallback) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	err = watcher.Watch(watchPath)
+
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	for {
+		select {
+		case <-watcher.Event:
+			filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
+				if path == ".git" {
+					return filepath.SkipDir
+				}
+
+				if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
+					cb(path)
+					startTime = time.Now()
+					return errors.New("done")
+				}
+
+				return nil
+			})
+		case err := <-watcher.Error:
+			logger.Fatal(err)
+		}
+	}
+}

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -5,10 +5,6 @@ package main
 
 import (
 	"code.google.com/p/go.exp/fsnotify"
-	"errors"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 func scanChanges(watchPath string, cb scanCallback) {
@@ -26,19 +22,7 @@ func scanChanges(watchPath string, cb scanCallback) {
 	for {
 		select {
 		case <-watcher.Event:
-			filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
-				if path == ".git" {
-					return filepath.SkipDir
-				}
-
-				if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
-					cb(path)
-					startTime = time.Now()
-					return errors.New("done")
-				}
-
-				return nil
-			})
+			walkPath(watchPath, cb)
 		case err := <-watcher.Error:
 			logger.Fatal(err)
 		}

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -5,7 +5,52 @@ package main
 
 import (
 	"code.google.com/p/go.exp/fsnotify"
+	"os"
+	"path/filepath"
+	"time"
 )
+
+// This is to prevent unneeded rebuilds
+var (
+	watched = make(map[string]bool)
+)
+
+func addPaths(watcher *fsnotify.Watcher, path string) error {
+	if watched[path] {
+		return nil
+	}
+
+	return filepath.Walk(path, func(wpath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if wpath == ".git" {
+			return filepath.SkipDir
+		}
+
+		if watched[wpath] {
+			return nil
+		}
+
+		if info.IsDir() {
+			watched[wpath] = true
+			err = watcher.Watch(wpath)
+			if err != nil {
+				return err
+			}
+			if path != wpath {
+				return addPaths(watcher, wpath)
+			}
+		} else {
+			if filepath.Ext(wpath) == ".go" {
+				watched[wpath] = true
+			}
+		}
+
+		return nil
+	})
+}
 
 func scanChanges(watchPath string, cb scanCallback) {
 	watcher, err := fsnotify.NewWatcher()
@@ -13,16 +58,44 @@ func scanChanges(watchPath string, cb scanCallback) {
 		logger.Fatal(err)
 	}
 
-	err = watcher.Watch(watchPath)
-
+	err = addPaths(watcher, watchPath)
 	if err != nil {
 		logger.Fatal(err)
 	}
 
 	for {
 		select {
-		case <-watcher.Event:
-			walkPath(watchPath, cb)
+		case ev := <-watcher.Event:
+			path := ev.Name
+			if watched[path] {
+				if ev.IsDelete() {
+					err = watcher.RemoveWatch(path)
+					if err != nil {
+						logger.Fatal(err)
+					}
+					watched[path] = false
+					continue
+				}
+
+				if filepath.Ext(path) == ".go" {
+					cb(path)
+					// Drain events that might have been triggered since this build
+					drain := true
+					for drain {
+						select {
+						case <-watcher.Event:
+						case <-time.After(250 * time.Millisecond):
+							drain = false
+						}
+					}
+				}
+			} else {
+				if ev.IsCreate() {
+					// We don't really care /too/ much if this fails...
+					addPaths(watcher, path)
+				}
+			}
+
 		case err := <-watcher.Error:
 			logger.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/codegangsta/envy/lib"
@@ -14,7 +13,6 @@ import (
 )
 
 var (
-	startTime  = time.Now()
 	logger     = log.New(os.Stdout, "[gin] ", 0)
 	buildError error
 )
@@ -120,20 +118,4 @@ func build(builder gin.Builder, logger *log.Logger) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-}
-
-func walkPath(watchPath string, cb scanCallback) {
-	filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
-		if path == ".git" {
-			return filepath.SkipDir
-		}
-
-		if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
-			cb(path)
-			startTime = time.Now()
-			return errors.New("done")
-		}
-
-		return nil
-	})
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/codegangsta/envy/lib"
@@ -18,6 +17,8 @@ var (
 	logger     = log.New(os.Stdout, "[gin] ", 0)
 	buildError error
 )
+
+type scanCallback func(path string)
 
 func main() {
 	app := cli.NewApp()
@@ -118,25 +119,4 @@ func build(builder gin.Builder, logger *log.Logger) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
-}
-
-type scanCallback func(path string)
-
-func scanChanges(watchPath string, cb scanCallback) {
-	for {
-		filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
-			if path == ".git" {
-				return filepath.SkipDir
-			}
-
-			if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
-				cb(path)
-				startTime = time.Now()
-				return errors.New("done")
-			}
-
-			return nil
-		})
-		time.Sleep(500 * time.Millisecond)
-	}
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"github.com/codegangsta/cli"
 	"github.com/codegangsta/envy/lib"
@@ -119,4 +120,20 @@ func build(builder gin.Builder, logger *log.Logger) {
 	}
 
 	time.Sleep(100 * time.Millisecond)
+}
+
+func walkPath(watchPath string, cb scanCallback) {
+	filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
+		if path == ".git" {
+			return filepath.SkipDir
+		}
+
+		if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
+			cb(path)
+			startTime = time.Now()
+			return errors.New("done")
+		}
+
+		return nil
+	})
 }

--- a/scan.go
+++ b/scan.go
@@ -4,12 +4,32 @@
 package main
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"time"
+)
+
+var (
+	startTime = time.Now()
 )
 
 func scanChanges(watchPath string, cb scanCallback) {
 	for {
-		walkPath(watchPath, cb)
+		filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
+			if path == ".git" {
+				return filepath.SkipDir
+			}
+
+			if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
+				cb(path)
+				startTime = time.Now()
+				return errors.New("done")
+			}
+
+			return nil
+		})
+
 		time.Sleep(500 * time.Millisecond)
 	}
 }

--- a/scan.go
+++ b/scan.go
@@ -4,27 +4,12 @@
 package main
 
 import (
-	"errors"
-	"os"
-	"path/filepath"
 	"time"
 )
 
 func scanChanges(watchPath string, cb scanCallback) {
 	for {
-		filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
-			if path == ".git" {
-				return filepath.SkipDir
-			}
-
-			if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
-				cb(path)
-				startTime = time.Now()
-				return errors.New("done")
-			}
-
-			return nil
-		})
+		walkPath(watchPath, cb)
 		time.Sleep(500 * time.Millisecond)
 	}
 }

--- a/scan.go
+++ b/scan.go
@@ -1,3 +1,6 @@
+//+build !fsnotify
+// The default is to build this scanner
+
 package main
 
 import (

--- a/scan.go
+++ b/scan.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func scanChanges(watchPath string, cb scanCallback) {
+	for {
+		filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
+			if path == ".git" {
+				return filepath.SkipDir
+			}
+
+			if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
+				cb(path)
+				startTime = time.Now()
+				return errors.New("done")
+			}
+
+			return nil
+		})
+		time.Sleep(500 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
This, at build time, enables fsnotify support for OS's that support it (e.g. Linux.) The this has a slight advantage over the default scanner in that there is almost zero delay between saving and triggering a rebuild.
