### PR TITLE
Wait() for forked processes

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -56,6 +56,7 @@ func (b *builder) Build() error {
 	if err != nil {
 		return err
 	}
+	go command.Wait()
 
 	errors, err := ioutil.ReadAll(stderr)
 	if err != nil {

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -78,6 +78,7 @@ func (r *runner) runBin() error {
 	if err != nil {
 		return err
 	}
+	go r.command.Wait()
 
 	r.starttime = time.Now()
 


### PR DESCRIPTION
gin does not call Wait() on the started processes, effectively creating
zombies everytime it builds or restarts the app. This rectifies that.
