### PR TITLE
Ignore hidden files as rebuild indicator

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,6 +129,11 @@ func scanChanges(watchPath string, cb scanCallback) {
 				return filepath.SkipDir
 			}
 
+			// ignore hidden files
+			if filepath.Base(path)[0] == '.' {
+				return nil
+			}
+
 			if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
 				cb(path)
 				startTime = time.Now()


### PR DESCRIPTION
Some editors (i.e. emacs) create a new (hidden) file to track changes
to files. Gin picks up on this new .go file and rebuilds. The go tool
chain ignores this file and so should gin.

``` bash
$ echo 'package main\nimport "fmt"\nfunc main() {\nfmt.Println("Hello")\n}' | gofmt > .t.go && go build
can't load package: package .: no buildable Go source files in /Users/brian/kill/test
```
