### PR TITLE
fix incredibly minor spelling error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ gin [![wercker status](https://app.wercker.com/status/f413ccbd85cfc4a58a37f03dd7
 
 `gin` is a simple command line utility for live-reloading Go web applications. Just run `gin` in your app directory and your web app will be served with `gin` as a proxy. `gin` will automatically recompile your code when it detects a change. Your app will be restarted the next time it receives an HTTP request.
 
-`gin` adhears to the "silence is golden" principle, so it will only complain if there was a compiler error or if you succesfully compile after an error.
+`gin` adheres to the "silence is golden" principle, so it will only complain if there was a compiler error or if you succesfully compile after an error.
 
 ## Installation
 


### PR DESCRIPTION
`adhears` -> `adheres`
