### PR TITLE
Fix killing in Windows

### DIFF
--- a/lib/runner.go
+++ b/lib/runner.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"runtime"
 	"time"
 )
 
@@ -64,7 +65,11 @@ func (r *runner) Kill() error {
 		}()
 
 		//Trying a "soft" kill first
-		if err := r.command.Process.Signal(os.Interrupt); err != nil {
+		if runtime.GOOS == "windows" {
+			if err := r.command.Process.Kill(); err != nil {
+				return err
+			}
+		} else if err := r.command.Process.Signal(os.Interrupt); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Hi, all

In windows, the second time of build always fails, saying "cannot create gin-bin.exe: Permission denied." This is because Go does not support Interrupt signal in Windows.

Though I fixed this, there is still a problem that errors of killing are not showed because of https://github.com/codegangsta/gin/blob/96e94cfee0ab2dc348501d64c9c28eb2ccde1605/main.go#L93 .

Thank you
