### PR TITLE
The '--path' option is no longer ignored.

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(".", c.GlobalString("bin"))
+	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"))
 	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()), c.Args()...)
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)


### PR DESCRIPTION
The path to source files was hardcoded to '.' instead of using the available parameter. This has been changed to use the passed in parameter.
