### PR TITLE
separate scan dir from executable/build dir

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -14,13 +14,14 @@ type Builder interface {
 }
 
 type builder struct {
+	execdir  string
 	dir      string
 	binary   string
 	errors   string
 	useGodep bool
 }
 
-func NewBuilder(dir string, bin string, useGodep bool) Builder {
+func NewBuilder(execdir string, dir string, bin string, useGodep bool) Builder {
 	if len(bin) == 0 {
 		bin = "bin"
 	}
@@ -32,7 +33,7 @@ func NewBuilder(dir string, bin string, useGodep bool) Builder {
 		}
 	}
 
-	return &builder{dir: dir, binary: bin, useGodep: useGodep}
+	return &builder{execdir: execdir, dir: dir, binary: bin, useGodep: useGodep}
 }
 
 func (b *builder) Binary() string {
@@ -50,7 +51,7 @@ func (b *builder) Build() error {
 	} else {
 		command = exec.Command("go", "build", "-o", b.binary)
 	}
-	command.Dir = b.dir
+	command.Dir = b.execdir
 
 	output, err := command.CombinedOutput()
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/codegangsta/envy/lib"
-	"github.com/kyleboyle/gin/lib"
+	"github.com/codegangsta/gin/lib"
 
 	"log"
 	"os"


### PR DESCRIPTION
I've found this feature useful for the scenario where a project has multiple sibling packages, one of those siblings being the executable, the other beings libs/utils.
example:
```
/project - base dir
/project/web - web server
/project/common - common buisness object and utilities
/project/batch - daemon processes

cd /project
gin -t . -e web
```
this will scan /project/* for changes and reload application defined in /project/web/

```gin -t .``` works as before
