### PR TITLE
Add more configuration options

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Config struct {
+	Bind    string `json:"bind"`
 	Port    int    `json:"port"`
 	ProxyTo string `json:"proxy_to"`
 }

--- a/lib/proxy.go
+++ b/lib/proxy.go
@@ -35,7 +35,7 @@ func (p *Proxy) Run(config *Config) error {
 	p.proxy = httputil.NewSingleHostReverseProxy(url)
 	p.to = url
 
-	p.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", config.Port))
+	p.listener, err = net.Listen("tcp", fmt.Sprintf("%s:%d", config.Bind, config.Port))
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -63,6 +63,11 @@ func main() {
 			Name:  "godep,g",
 			Usage: "use godep when building",
 		},
+		cli.StringFlag{
+			Name:  "build,d",
+			Value: "",
+			Usage: "Path to build files from (defaults to same value as --path)",
+		},
 	}
 	app.Commands = []cli.Command{
 		{
@@ -98,7 +103,11 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))
+	buildPath := c.GlobalString("build")
+	if buildPath == "" {
+		buildPath = c.GlobalString("path")
+	}
+	builder := gin.NewBuilder(buildPath, c.GlobalString("bin"), c.GlobalBool("godep"))
 	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()), c.Args()...)
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)

--- a/main.go
+++ b/main.go
@@ -46,6 +46,11 @@ func main() {
 			Usage: "name of generated binary file",
 		},
 		cli.StringFlag{
+			Name:  "bind,n",
+			Value: "",
+			Usage: "Interface to bind for the Gin proxy server",
+		},
+		cli.StringFlag{
 			Name:  "path,t",
 			Value: ".",
 			Usage: "Path to watch files from",
@@ -99,6 +104,7 @@ func MainAction(c *cli.Context) {
 	proxy := gin.NewProxy(builder, runner)
 
 	config := &gin.Config{
+		Bind:    c.GlobalString("bind"),
 		Port:    port,
 		ProxyTo: "http://localhost:" + appPort,
 	}
@@ -108,7 +114,11 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	logger.Printf("listening on port %d\n", port)
+	if config.Bind != "" {
+		logger.Printf("listening on %s:%d\n", config.Bind, port)
+	} else {
+		logger.Printf("listening on port %d\n", port)
+	}
 
 	shutdown(runner)
 


### PR DESCRIPTION
This PR allows the user to:

1) Bind a particular interface. This is useful both for security (so you don't expose your development server), and also lets you bind to 127.0.0.1 to prevent OSX from launching a warning dialog when your firewall's on. (I avoided this to retain backwards-compatibility, but the ideal default would be to bind to 127.0.0.1.)

2) Choose a separate build and watch path. This is useful for many projects which nest their main packages inside of the repository.