### PR TITLE
added constabulary/gb builder

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -3,8 +3,12 @@ package gin
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/constabulary/gb"
+	gbCmd "github.com/constabulary/gb/cmd"
 )
 
 type Builder interface {
@@ -65,4 +69,103 @@ func (b *builder) Build() error {
 	}
 
 	return err
+}
+
+type gbBuilder struct {
+	dir  string
+	root string
+	proj *gb.Project
+
+	pkg *gb.Package
+	bin string
+	err error
+}
+
+// NewGbBuilder creates a constabulary/gb builder using dir to find the $porject root and for the main pkg as well
+// if dir == . it uses the current working directory of gin
+// i.e dir == /home/meh/devel/proj/src/spcil/cmd/worker
+// => $proj = /home/meh/devel/proj
+// => main pkg = spcil/cmd/worker
+// TODO(cryptix): maybe use --bin flag to sepcify main pkg?
+func NewGbBuilder(dir string) Builder {
+	b := new(gbBuilder)
+
+	if dir == "." {
+		dir = gbCmd.MustGetwd()
+	}
+	b.dir = dir
+
+	var err error
+	b.root, err = gbCmd.FindProjectroot(b.dir)
+	if err != nil {
+		b.err = fmt.Errorf("gb cmd.FindProjectroot(%q) failed:  %v", b.dir, err)
+		return b
+	}
+	b.proj = gb.NewProject(b.root)
+
+	if err := b.importResolveBuild(false); err != nil {
+		b.err = fmt.Errorf("importAndResolve() failed: %v", err)
+		return b
+	}
+
+	return b
+}
+
+func (b *gbBuilder) Binary() string {
+	p := b.proj.Bindir()
+	p += "/" + b.bin
+	return p
+}
+
+func (b *gbBuilder) Errors() string {
+	if b.err != nil {
+		return b.err.Error()
+	}
+	return ""
+}
+
+func (b *gbBuilder) Build() error {
+	if b.err != nil {
+		return b.err
+	}
+
+	return b.importResolveBuild(true)
+}
+
+// importResolveBuild does everything because you can't reuse ResolvePackages return values
+// if their imports changed and broke gb.Build will be confused what to do
+func (b *gbBuilder) importResolveBuild(build bool) error {
+	ctx, err := b.proj.NewContext()
+	if err != nil {
+		return fmt.Errorf("proj.NewContext() failed: %v", err)
+
+	}
+
+	args := gbCmd.ImportPaths(ctx, b.dir, []string{}) // args..?!
+	if len(args) < 1 {
+		return fmt.Errorf("No ImportPaths.")
+
+	}
+	b.bin = filepath.Base(args[0])
+
+	pkgs, err := gbCmd.ResolvePackages(ctx, args[0])
+	if err != nil {
+		return fmt.Errorf("gb cmd.ResolvePackages(%q) failed: %v", args[0], err)
+	}
+	if len(pkgs) < 1 {
+		return fmt.Errorf("No Pakages.")
+	}
+
+	if build {
+		if err := gb.Build(pkgs[0]); err != nil {
+			return fmt.Errorf("gb.Build(%s) failed: %v", pkgs[0], err)
+		}
+	}
+
+	if err := ctx.Destroy(); err != nil {
+		return fmt.Errorf("ctx.Destroy() failed: %v", err)
+
+	}
+
+	return nil
 }

--- a/lib/builder.go
+++ b/lib/builder.go
@@ -125,10 +125,6 @@ func (b *gbBuilder) Errors() string {
 }
 
 func (b *gbBuilder) Build() error {
-	if b.err != nil {
-		return b.err
-	}
-
 	if err := b.importResolveBuild(true); err != nil {
 		b.err = err
 		return b.err
@@ -171,6 +167,6 @@ func (b *gbBuilder) importResolveBuild(build bool) error {
 		return fmt.Errorf("ctx.Destroy() failed: %v", err)
 
 	}
-
+	b.err = nil
 	return nil
 }

--- a/lib/builder.go
+++ b/lib/builder.go
@@ -129,7 +129,12 @@ func (b *gbBuilder) Build() error {
 		return b.err
 	}
 
-	return b.importResolveBuild(true)
+	if err := b.importResolveBuild(true); err != nil {
+		b.err = err
+		return b.err
+	}
+
+	return nil
 }
 
 // importResolveBuild does everything because you can't reuse ResolvePackages return values

--- a/lib/builder_test.go
+++ b/lib/builder_test.go
@@ -26,3 +26,21 @@ func Test_Builder_Build_Success(t *testing.T) {
 
 	refute(t, file, nil)
 }
+
+func Test_GbBuilder_Build_Success(t *testing.T) {
+	wd := filepath.Join("test_fixtures", "build_gbProj", "src", "test1")
+
+	builder := gin.NewGbBuilder(wd)
+	expect(t, builder.Errors(), "")
+
+	binPath := filepath.Join("test_fixtures", "build_gbProj", "bin", "test1")
+	expect(t, builder.Binary(), binPath)
+
+	err := builder.Build()
+	expect(t, err, nil)
+
+	file, err := os.Open(binPath)
+	expect(t, err, nil)
+
+	refute(t, file, nil)
+}

--- a/lib/test_fixtures/build_gbProj/src/test1/main.go
+++ b/lib/test_fixtures/build_gbProj/src/test1/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("Good to go")
+}

--- a/main.go
+++ b/main.go
@@ -58,6 +58,10 @@ func main() {
 			Name:  "godep,g",
 			Usage: "use godep when building",
 		},
+		cli.BoolFlag{
+			Name:  "gb",
+			Usage: "use gb when building",
+		},
 	}
 	app.Commands = []cli.Command{
 		{
@@ -93,8 +97,18 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))
-	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()), c.Args()...)
+	var (
+		path    string
+		builder gin.Builder
+	)
+	if c.GlobalBool("gb") {
+		builder = gin.NewGbBuilder(c.GlobalString("path"))
+		path = builder.Binary()
+	} else {
+		builder = gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))
+		path = filepath.Join(wd, builder.Binary())
+	}
+	runner := gin.NewRunner(path, c.Args()...)
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)
 


### PR DESCRIPTION
Hi!

This PR adds a basic [gb](http://getgb.io/) builder to gin.

It currently uses the `--path` flag for its main package location and looks up `$project` from there. If `--path == .` it uses the current working directory.

I decided  against shelling out to `gb build` through `os/exec` because I wanted its project detection anyway and calling `gb.Build` then with the resolved packages was just one more step.