### PR TITLE
updates README about help

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go get github.com/codegangsta/gin
 Then verify that `gin` was installed correctly:
 
 ```shell
-gin -h
+gin help
 ```
 
 ## Supporting Gin in Your Web app


### PR DESCRIPTION
Running `gin -h` doesn't show the help, but `gin help` does.

Related: https://github.com/codegangsta/gin/issues/75
