### PR TITLE
Return error immediately if builder.Build() fails.

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -53,6 +53,9 @@ func (b *builder) Build() error {
 	command.Dir = b.dir
 
 	output, err := command.CombinedOutput()
+	if err != nil {
+		return err
+	}
 
 	if command.ProcessState.Success() {
 		b.errors = ""
@@ -64,5 +67,5 @@ func (b *builder) Build() error {
 		return fmt.Errorf(b.errors)
 	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
If the command fails, command.ProcessState will be nil and
command.ProcessState.Success() in lib/builder.go:60 will panic with a
nil pointer error.