### PR TITLE
New gb flag for building with getgb.io

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -18,9 +18,10 @@ type builder struct {
 	binary   string
 	errors   string
 	useGodep bool
+	useGb    bool
 }
 
-func NewBuilder(dir string, bin string, useGodep bool) Builder {
+func NewBuilder(dir string, bin string, useGodep bool, useGb bool) Builder {
 	if len(bin) == 0 {
 		bin = "bin"
 	}
@@ -32,7 +33,7 @@ func NewBuilder(dir string, bin string, useGodep bool) Builder {
 		}
 	}
 
-	return &builder{dir: dir, binary: bin, useGodep: useGodep}
+	return &builder{dir: dir, binary: bin, useGodep: useGodep, useGb: useGb}
 }
 
 func (b *builder) Binary() string {
@@ -47,6 +48,8 @@ func (b *builder) Build() error {
 	var command *exec.Cmd
 	if b.useGodep {
 		command = exec.Command("godep", "go", "build", "-o", b.binary)
+	} else if b.useGb {
+		command = exec.Command("gb", "build")
 	} else {
 		command = exec.Command("go", "build", "-o", b.binary)
 	}

--- a/lib/builder_test.go
+++ b/lib/builder_test.go
@@ -15,7 +15,7 @@ func Test_Builder_Build_Success(t *testing.T) {
 		bin += ".exe"
 	}
 
-	builder := gin.NewBuilder(wd, bin, false)
+	builder := gin.NewBuilder(wd, bin, false, false)
 	err := builder.Build()
 	expect(t, err, nil)
 

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "bin,b",
 			Value: "gin-bin",
-			Usage: "name of generated binary file",
+			Usage: "name of generated binary file. If using gb, absolute path to binary file.",
 		},
 		cli.StringFlag{
 			Name:  "path,t",
@@ -57,6 +57,10 @@ func main() {
 		cli.BoolFlag{
 			Name:  "godep,g",
 			Usage: "use godep when building",
+		},
+		cli.BoolFlag{
+			Name:  "usegb,gb",
+			Usage: "use gb when building",
 		},
 	}
 	app.Commands = []cli.Command{
@@ -93,8 +97,14 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))
-	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()), c.Args()...)
+	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"), c.GlobalBool("gb"))
+
+	binFilepath := filepath.Join(wd, builder.Binary())
+	if c.GlobalBool("gb") {
+		binFilepath = builder.Binary()
+	}
+	runner := gin.NewRunner(binFilepath, c.Args()...)
+
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)
 


### PR DESCRIPTION
This commit brings support for the gb build system (http://getgb.io/) by passing in a --usegb / -gb flag. 

Unfortunately, Gb doesn't currently support arbitrary naming of build output files (See: https://github.com/constabulary/gb/issues/97). This means I couldn't follow the same template used for godep support, and instead I adjusted the documentation to point out that enabling Gb means you must use an absolute path for the --bin flag so gin knows where to run the executable after it is built. 

