### PR TITLE
Build bin relative to the working directory

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -3,6 +3,7 @@ package gin
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -18,9 +19,10 @@ type builder struct {
 	binary   string
 	errors   string
 	useGodep bool
+	wd       string
 }
 
-func NewBuilder(dir string, bin string, useGodep bool) Builder {
+func NewBuilder(dir string, bin string, useGodep bool, wd string) Builder {
 	if len(bin) == 0 {
 		bin = "bin"
 	}
@@ -32,7 +34,7 @@ func NewBuilder(dir string, bin string, useGodep bool) Builder {
 		}
 	}
 
-	return &builder{dir: dir, binary: bin, useGodep: useGodep}
+	return &builder{dir: dir, binary: bin, useGodep: useGodep, wd: wd}
 }
 
 func (b *builder) Binary() string {
@@ -46,9 +48,9 @@ func (b *builder) Errors() string {
 func (b *builder) Build() error {
 	var command *exec.Cmd
 	if b.useGodep {
-		command = exec.Command("godep", "go", "build", "-o", b.binary)
+		command = exec.Command("godep", "go", "build", "-o", filepath.Join(b.wd, b.binary))
 	} else {
-		command = exec.Command("go", "build", "-o", b.binary)
+		command = exec.Command("go", "build", "-o", filepath.Join(b.wd, b.binary))
 	}
 	command.Dir = b.dir
 

--- a/lib/builder_test.go
+++ b/lib/builder_test.go
@@ -1,22 +1,28 @@
 package gin_test
 
 import (
-	"github.com/codegangsta/gin/lib"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/codegangsta/gin/lib"
 )
 
 func Test_Builder_Build_Success(t *testing.T) {
-	wd := filepath.Join("test_fixtures", "build_success")
+	dir := filepath.Join("test_fixtures", "build_success")
 	bin := "build_success"
 	if runtime.GOOS == "windows" {
 		bin += ".exe"
 	}
 
-	builder := gin.NewBuilder(wd, bin, false)
-	err := builder.Build()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Could not get working directory: %v", err)
+	}
+
+	builder := gin.NewBuilder(dir, bin, false, wd)
+	err = builder.Build()
 	expect(t, err, nil)
 
 	file, err := os.Open(filepath.Join(wd, bin))

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))
+	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"), wd)
 	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()), c.Args()...)
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)


### PR DESCRIPTION
Prevents unknown bin location when the path flag is set. Before, the
binary was getting placed in the path location and the runner was trying
to execute from the working path without success.
