### PR TITLE
Add command line flag "--ext" (short "-e") to specify a list of file extensions to watch

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,11 @@ func main() {
 			Value: "gin-bin",
 			Usage: "name of generated binary file",
 		},
+		cli.StringSliceFlag{
+			Name:  "ext,e",
+			Usage: "Use ext to specify the file extensions to listen to.",
+			Value: &cli.StringSlice{".go"},
+		},
 		cli.StringFlag{
 			Name:  "path,t",
 			Value: ".",
@@ -116,7 +121,7 @@ func MainAction(c *cli.Context) {
 	build(builder, runner, logger)
 
 	// scan for changes
-	scanChanges(c.GlobalString("path"), func(path string) {
+	scanChanges(c.GlobalString("path"), c.GlobalStringSlice("ext"), func(path string) {
 		runner.Kill()
 		build(builder, runner, logger)
 	})
@@ -157,7 +162,16 @@ func build(builder gin.Builder, runner gin.Runner, logger *log.Logger) {
 
 type scanCallback func(path string)
 
-func scanChanges(watchPath string, cb scanCallback) {
+func in(str string, arr []string) bool {
+	for _, v := range arr {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}
+
+func scanChanges(watchPath string, ext []string, cb scanCallback) {
 	for {
 		filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
 			if path == ".git" {
@@ -169,7 +183,7 @@ func scanChanges(watchPath string, cb scanCallback) {
 				return nil
 			}
 
-			if filepath.Ext(path) == ".go" && info.ModTime().After(startTime) {
+			if in(filepath.Ext(path), ext) && info.ModTime().After(startTime) {
 				cb(path)
 				startTime = time.Now()
 				return errors.New("done")


### PR DESCRIPTION
Addresses issue https://github.com/codegangsta/gin/issues/44.
Restarting on template change can be achieved using flags "-e .go -e .html".

I needed to restart the server when I edit templates, and I see others have this issue too. This is a really simple solution by just adding a command line flag --ext (short -e), which is an array of strings, so one can do, for example:

    gin -e .go -e .html

I would really appreciate any feedback.

Thanks
Vlad