### PR TITLE
Runner should respect "--path"

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,9 +88,13 @@ func MainAction(c *cli.Context) {
 	// Set the PORT env
 	os.Setenv("PORT", appPort)
 
+	// Working directory is where we expect the built output to live.
 	wd, err := os.Getwd()
 	if err != nil {
 		logger.Fatal(err)
+	}
+	if c.GlobalString("path") != "." {
+		wd = c.GlobalString("path")
 	}
 
 	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))


### PR DESCRIPTION
The path the Runner was using to find the temporarily built binary was
not respecting the "--path" flag.