### PR TITLE
Handling error from calling wait

### DIFF
--- a/lib/runner.go
+++ b/lib/runner.go
@@ -61,7 +61,12 @@ func (r *runner) Kill() error {
 	if r.command != nil && r.command.Process != nil {
 		done := make(chan error)
 		go func() {
-			r.command.Wait()
+			if err := r.command.Wait(); err != nil {
+				// If wait fails to run we kill after a timeout of 3 seconds below, so
+				// this is okay.
+				log.Println("failed to run wait: ", err)
+				return
+			}
 			close(done)
 		}()
 


### PR DESCRIPTION
Calling command.Wait can return an error. In our application trying to kill gin would not kill the application because the error was not being handled so gin incorrectly thought the application exited. This makes it so the fallback will be used in that case.

Note that the error returned for our application is `Wait was already called`. I presume that this is caused by https://github.com/codegangsta/gin/blob/master/lib/runner.go#L115

This can probably be fixed by calling Wait once and sending messages down channels, but this was the quick fix.
