### PR TITLE
New main path flag

### DIFF
--- a/lib/builder.go
+++ b/lib/builder.go
@@ -17,10 +17,11 @@ type builder struct {
 	dir      string
 	binary   string
 	errors   string
+	mainPath string
 	useGodep bool
 }
 
-func NewBuilder(dir string, bin string, useGodep bool) Builder {
+func NewBuilder(dir string, bin string, useGodep bool, mainPath string) Builder {
 	if len(bin) == 0 {
 		bin = "bin"
 	}
@@ -32,7 +33,7 @@ func NewBuilder(dir string, bin string, useGodep bool) Builder {
 		}
 	}
 
-	return &builder{dir: dir, binary: bin, useGodep: useGodep}
+	return &builder{dir: dir, binary: bin, mainPath: mainPath, useGodep: useGodep}
 }
 
 func (b *builder) Binary() string {
@@ -46,9 +47,9 @@ func (b *builder) Errors() string {
 func (b *builder) Build() error {
 	var command *exec.Cmd
 	if b.useGodep {
-		command = exec.Command("godep", "go", "build", "-o", b.binary)
+		command = exec.Command("godep", "go", "build", "-o", b.binary, b.mainPath)
 	} else {
-		command = exec.Command("go", "build", "-o", b.binary)
+		command = exec.Command("go", "build", "-o", b.binary, b.mainPath)
 	}
 	command.Dir = b.dir
 

--- a/main.go
+++ b/main.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/urfave/cli.v1"
 	"github.com/codegangsta/envy/lib"
-	"github.com/codegangsta/gin/lib"
+	"github.com/sfroment/gin/lib"
+	"gopkg.in/urfave/cli.v1"
 
 	"log"
 	"os"
@@ -49,6 +49,11 @@ func main() {
 			Name:  "path,t",
 			Value: ".",
 			Usage: "Path to watch files from",
+		},
+		cli.StringFlag{
+			Name:  "main-path,mt",
+			Value: ".",
+			Usage: "Absolute path to main",
 		},
 		cli.BoolFlag{
 			Name:  "immediate,i",
@@ -93,7 +98,7 @@ func MainAction(c *cli.Context) {
 		logger.Fatal(err)
 	}
 
-	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"))
+	builder := gin.NewBuilder(c.GlobalString("path"), c.GlobalString("bin"), c.GlobalBool("godep"), c.GlobalString("main-path"))
 	runner := gin.NewRunner(filepath.Join(wd, builder.Binary()), c.Args()...)
 	runner.SetWriter(os.Stdout)
 	proxy := gin.NewProxy(builder, runner)


### PR DESCRIPTION
Hello,

I work on project with a similar filesystem hierarchy as https://github.com/scaleway/scaleway-cli so I need to be able to launch gin with the godep but if I'm not in the directory of the main gin won't know which binary to build.

This commit fix this problem by adding a flag to specify where the main to build is.
If you have a better idea to implement a feature that solve the kind of problem I'm facing tell me I will be happy to implement it.
