### PR TITLE
Don't skip directory accidentally if .git is a file instead of a dir

### DIFF
--- a/main.go
+++ b/main.go
@@ -206,7 +206,7 @@ type scanCallback func(path string)
 func scanChanges(watchPath string, excludeDirs []string, allFiles bool, cb scanCallback) {
 	for {
 		filepath.Walk(watchPath, func(path string, info os.FileInfo, err error) error {
-			if path == ".git" {
+			if path == ".git" && info.IsDir(){
 				return filepath.SkipDir
 			}
 			for _, x := range excludeDirs {


### PR DESCRIPTION
Caught this bug trying to use gin to monitor changes in a git submodule. In this case, ".git" is a plaintext file instead of a directory. When gin is walking the directory, it returns "filepath.SkipDir" when the current path is named ".git". If .git is not a directory though, this makes gin give up on monitoring the remaining files on the directory.