### PR TITLE
Add possibility to set up custom log prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 gin [![wercker status](https://app.wercker.com/status/f413ccbd85cfc4a58a37f03dd7aaa87e "wercker status")](https://app.wercker.com/project/bykey/f413ccbd85cfc4a58a37f03dd7aaa87e)
 ========
 
-`gin` is a simple command line utility for live-reloading Go web applications. 
-Just run `gin` in your app directory and your web app will be served with 
-`gin` as a proxy. `gin` will automatically recompile your code when it 
-detects a change. Your app will be restarted the next time it receives an 
+`gin` is a simple command line utility for live-reloading Go web applications.
+Just run `gin` in your app directory and your web app will be served with
+`gin` as a proxy. `gin` will automatically recompile your code when it
+detects a change. Your app will be restarted the next time it receives an
 HTTP request.
 
-`gin` adheres to the "silence is golden" principle, so it will only complain 
+`gin` adheres to the "silence is golden" principle, so it will only complain
 if there was a compiler error or if you succesfully compile after an error.
 
 ## Installation
 
-Assuming you have a working Go environment and `GOPATH/bin` is in your 
+Assuming you have a working Go environment and `GOPATH/bin` is in your
 `PATH`, `gin` is a breeze to install:
 
 ```shell
@@ -24,7 +24,7 @@ Then verify that `gin` was installed correctly:
 ```shell
 gin -h
 ```
-## Basic usage 
+## Basic usage
 ```shell
 gin run main.go
 ```
@@ -43,18 +43,19 @@ Options
    --buildArgs value             Additional go build arguments
    --certFile value              TLS Certificate
    --keyFile value               TLS Certificate Key
+   --logPrefix value             Setup custom log prefix
    --help, -h                    show help
    --version, -v                 print the version
 ```
 
 ## Supporting Gin in Your Web app
-`gin` assumes that your web app binds itself to the `PORT` environment 
-variable so it can properly proxy requests to your app. Web frameworks 
-like [Martini](http://github.com/codegangsta/martini) do this out of 
+`gin` assumes that your web app binds itself to the `PORT` environment
+variable so it can properly proxy requests to your app. Web frameworks
+like [Martini](http://github.com/codegangsta/martini) do this out of
 the box.
 
 ## Using flags?
 When you normally start your server with [flags](https://godoc.org/flag)
-if you want to override any of them when running `gin` we suggest you 
+if you want to override any of them when running `gin` we suggest you
 instead use [github.com/namsral/flag](https://github.com/namsral/flag)
 as explained in [this post](http://stackoverflow.com/questions/24873883/organizing-environment-variables-golang/28160665#28160665)

--- a/main.go
+++ b/main.go
@@ -106,6 +106,12 @@ func main() {
 			EnvVar: "GIN_KEY_FILE",
 			Usage:  "TLS Certificate Key",
 		},
+		cli.StringFlag{
+			Name:   "logPrefix",
+			EnvVar: "GIN_LOG_PREFIX",
+			Usage:  "Log prefix",
+			Value:  "gin",
+		},
 	}
 	app.Commands = []cli.Command{
 		{
@@ -133,6 +139,9 @@ func MainAction(c *cli.Context) {
 	immediate = c.GlobalBool("immediate")
 	keyFile := c.GlobalString("keyFile")
 	certFile := c.GlobalString("certFile")
+	logPrefix := c.GlobalString("logPrefix")
+
+	logger.SetPrefix(fmt.Sprintf("[%s] ", logPrefix))
 
 	// Bootstrap the environment
 	envy.Bootstrap()
@@ -191,6 +200,9 @@ func MainAction(c *cli.Context) {
 }
 
 func EnvAction(c *cli.Context) {
+	logPrefix := c.GlobalString("logPrefix")
+	logger.SetPrefix(fmt.Sprintf("[%s] ", logPrefix))
+
 	// Bootstrap the environment
 	env, err := envy.Bootstrap()
 	if err != nil {


### PR DESCRIPTION
Sometime we develop multiple projects (my micro-services) at the same time, So running multiple instances of gin simultaneously confuse me sometimes. This will help recognize building projects faster.