### PR TITLE
Add cli flag 'httpHeaders' that enables settings proxy's http response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options
    --keyFile value               TLS Certificate Key
    --logPrefix value             Setup custom log prefix
    --notifications               enable desktop notifications
+   --httpHeader                  adds a http response header. eg. --httpHeader "Server:gin"
    --help, -h                    show help
    --version, -v                 print the version
 ```

--- a/lib/config.go
+++ b/lib/config.go
@@ -7,11 +7,12 @@ import (
 )
 
 type Config struct {
-	Laddr    string `json:"laddr"`
-	Port     int    `json:"port"`
-	ProxyTo  string `json:"proxy_to"`
-	KeyFile  string `json:"key_file"`
-	CertFile string `json:"cert_file"`
+	Laddr       string            `json:"laddr"`
+	Port        int               `json:"port"`
+	ProxyTo     string            `json:"proxy_to"`
+	KeyFile     string            `json:"key_file"`
+	CertFile    string            `json:"cert_file"`
+	HttpHeaders map[string]string `json:"http_headers"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/lib/config_test.go
+++ b/lib/config_test.go
@@ -11,6 +11,7 @@ func Test_LoadConfig(t *testing.T) {
 	expect(t, err, nil)
 	expect(t, config.Port, 5678)
 	expect(t, config.ProxyTo, "http://localhost:3000")
+	expect(t, config.HttpHeaders["Server"], "my-service")
 }
 
 func Test_LoadConfig_WithNonExistantFile(t *testing.T) {

--- a/lib/test_fixtures/config.json
+++ b/lib/test_fixtures/config.json
@@ -1,4 +1,7 @@
 {
   "port": 5678,
-  "proxy_to": "http://localhost:3000"
+  "proxy_to": "http://localhost:3000",
+  "http_headers":{
+    "Server":"my-service"
+  }
 }

--- a/main.go
+++ b/main.go
@@ -215,6 +215,7 @@ func MainAction(c *cli.Context) {
 		build(builder, runner, logger)
 	})
 }
+
 func parseHttpHeader(slice []string) map[string]string {
 	header := map[string]string{}
 	for _, v := range slice {


### PR DESCRIPTION
Hey, what do you think of this feature?
For me gin acts as some kind of server in front of a go service.
Since I'd like to run integrity tests on my docker-compose environment I'd like gin to pass
back some custom header.

Of course I could add the header in my application. But I'd like to receive it from gin since my tests just need some robust endpoint - and the application relies on a git repository which may be not as robust as the compiled gin in my container.