### PR TITLE
Update import gopkg.in/urfave/cli.v1 -> github.com/urfave/cli

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/codegangsta/envy/lib"
 	"github.com/codegangsta/gin/lib"
 	shellwords "github.com/mattn/go-shellwords"
-	"gopkg.in/urfave/cli.v1"
+	"github.com/urfave/cli"
 
 	"github.com/0xAX/notificator"
 	"log"


### PR DESCRIPTION
Since  github.com/urfave/cli started supporting go modules (and named the module  github.com/urfave/cli), it should be referenced by the new name to work when using GO111MODULE=on

https://github.com/codegangsta/gin/issues/154