### PR TITLE
Gopkg.in/urfave/cli.v1 package cannot be used in China

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/codegangsta/envy/lib"
 	"github.com/codegangsta/gin/lib"
 	shellwords "github.com/mattn/go-shellwords"
-	"gopkg.in/urfave/cli.v1"
+	"github.com/urfave/cli"
 
 	"github.com/0xAX/notificator"
 	"log"


### PR DESCRIPTION
in china 
build github.com/codegangsta/gin: cannot load gopkg.in/urfave/cli.v1: cannot find module providing package gopkg.in/urfave/cli.v1

Modify to the github package, which can be used by developers in China. 