### PR TITLE
Config.Laddr default value localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go get github.com/codegangsta/gin
 Then verify that `gin` was installed correctly:
 
 ```shell
-gin -h
+gin help
 ```
 ## Basic usage
 ```shell

--- a/lib/helpers_test.go
+++ b/lib/helpers_test.go
@@ -1,19 +1,29 @@
 package gin_test
 
 import (
+	"fmt"
 	"reflect"
+	"runtime"
 	"testing"
 )
+
+func getCaller() string {
+	_, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return "Unrecoverable location"
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}
 
 /* Test Helpers */
 func expect(t *testing.T, a interface{}, b interface{}) {
 	if a != b {
-		t.Errorf("Expected %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+		t.Errorf("Expected %v (type %v) - Got %v (type %v) at %s", b, reflect.TypeOf(b), a, reflect.TypeOf(a), getCaller())
 	}
 }
 
 func refute(t *testing.T, a interface{}, b interface{}) {
 	if a == b {
-		t.Errorf("Did not expect %v (type %v) - Got %v (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
+		t.Errorf("Did not expect %v (type %v) - Got %v (type %v) at %s", b, reflect.TypeOf(b), a, reflect.TypeOf(a), getCaller())
 	}
 }

--- a/lib/proxy.go
+++ b/lib/proxy.go
@@ -27,6 +27,10 @@ func NewProxy(builder Builder, runner Runner) *Proxy {
 }
 
 func (p *Proxy) Run(config *Config) error {
+	// set Laddr to localhost if empty to avoid firewall permissions
+	if config.Laddr == ""{
+		config.Laddr = "127.0.0.1"
+	}
 
 	// create our reverse proxy
 	url, err := url.Parse(config.ProxyTo)


### PR DESCRIPTION
When creating a listener with an empty address, the listener will assume any interface (0.0.0.0). This will trigger firewall permissions to be granted every time a unique binary is generated. This can be problematic during tests as the binary has a unique name by default.

Since this is a proxy for development sake. It is safe to assume if Config.Laddr is not provided we can use localhost to avoid the firewall module.