### PR TITLE
Config.Laddr default value localhost.

### DIFF
--- a/lib/proxy.go
+++ b/lib/proxy.go
@@ -27,6 +27,10 @@ func NewProxy(builder Builder, runner Runner) *Proxy {
 }
 
 func (p *Proxy) Run(config *Config) error {
+	// set Laddr to localhost if empty to avoid firewall permissions
+	if config.Laddr == "" {
+		config.Laddr = "127.0.0.1"
+	}
 
 	// create our reverse proxy
 	url, err := url.Parse(config.ProxyTo)


### PR DESCRIPTION
When creating a listener with an empty address, the listener will assume any interface (0.0.0.0). This will trigger firewall permissions to be granted every time a unique binary is generated. This can be problematic during tests as the binary has a unique name by default.

Since this is a proxy for development sake. It is safe to assume if Config.Laddr is not provided we can use localhost to avoid the firewall module.