### PR TITLE
Updated README.md with new install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Assuming you have a working Go environment and `GOPATH/bin` is in your
 `PATH`, `gin` is a breeze to install:
 
 ```shell
-go get github.com/codegangsta/gin
+go install github.com/codegangsta/gin@latest
 ```
 
 Then verify that `gin` was installed correctly:


### PR DESCRIPTION
'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version,
like 'go install example.com/cmd@latest'

see https://github.com/golang/go/issues/40276